### PR TITLE
chore/render-keepalive

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root "lists#index"
+  root 'lists#index'
 
   devise_for :users
 
@@ -7,5 +7,6 @@ Rails.application.routes.draw do
     resources :lists
   end
 
-  get "lists/index"
+  # Render スリープ対策用のヘルスチェック
+  get 'healthcheck', to: proc { [200, { 'Content-Type' => 'text/plain' }, ['ok']] }
 end


### PR DESCRIPTION
## 概要
Render の Free プランでアプリが自動スリープしてしまう問題に対して、
定期的にアプリにアクセスするヘルスチェックエンドポイントを追加し、
Google Apps Script から定期的に叩く設定を施しスリープしにくくなるようにしました。

## 変更内容
- `/healthcheck` エンドポイントを追加
- GAS から定期的に `/healthcheck` を叩く運用を想定（`keepAlive` 関数）

## 変更ファイル
- `config/routes.rb`

## 動作確認
- [x] `bin/rails routes` で `/healthcheck` が登録されていることを確認
- [x] ローカル環境で `http://localhost:3000/healthcheck` にアクセスし `ok` が返ることを確認
- [x] 本番環境（Render）で `/healthcheck` にアクセスし 200 OK が返ることを確認

## 関連Issue
close #55 