### PR TITLE
Add user profile fields and profile pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ https://www.figma.com/design/LEEt7T5T72Ts4IjRKVjc0u/%E5%8D%92%E5%88%B6-AiRoute-?
 ---
 
 ## ER図
-[![Image from Gyazo](https://i.gyazo.com/9321d9021a793f64c072d3b9d9e9ff5e.png)](https://gyazo.com/9321d9021a793f64c072d3b9d9e9ff5e)
+[![Image from Gyazo](https://i.gyazo.com/0faff74df14ddd729e5dc1c08a67454d.png)](https://gyazo.com/0faff74df14ddd729e5dc1c08a67454d)
 
 ---
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,9 +2,19 @@
 
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
   allow_browser versions: :modern
 
   private
+
+  # Devise の Strong Parameters
+  def configure_permitted_parameters
+    added_attrs = %i[name avatar_url profile]
+
+    devise_parameter_sanitizer.permit(:sign_up, keys: added_attrs)
+    devise_parameter_sanitizer.permit(:account_update, keys: added_attrs)
+  end
 
   # ログイン後の遷移先
   def after_sign_in_path_for(_resource)

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class ProfilesController < ApplicationController
+  before_action :set_user
+
+  def show; end
+
+  def edit; end
+
+  def update
+    if @user.update(profile_params)
+      redirect_to profile_path, notice: 'プロフィールを更新しました。'
+    else
+      flash.now[:alert] = 'プロフィールの更新に失敗しました。'
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_user
+    @user = current_user
+  end
+
+  def profile_params
+    params.require(:user).permit(:name, :avatar_url, :profile)
+  end
+end

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module ProfilesHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,11 @@ class User < ApplicationRecord
   has_many :lists, dependent: :destroy
   has_many :spots, dependent: :destroy
 
+  # プロフィール用バリデーション
+  validates :name, length: { maximum: 50 }, allow_blank: true
+  validates :profile, length: { maximum: 300 }, allow_blank: true
+  validates :avatar_url, length: { maximum: 255 }, allow_blank: true
+
   devise :database_authenticatable,
          :registerable,
          :recoverable,

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,63 @@
+<div class="min-h-[60vh] bg-slate-50">
+  <div class="max-w-md mx-auto px-4 py-8 space-y-4">
+    <div>
+      <h1 class="text-xl font-bold text-emerald-600">
+        プロフィールを編集
+      </h1>
+      <p class="mt-1 text-xs text-gray-600">
+        名前やひとこと自己紹介を入力できます
+      </p>
+    </div>
+
+    <div class="bg-white rounded-xl shadow-sm border border-slate-200 p-5">
+      <%= form_with model: @user, url: profile_path, local: true, class: "space-y-5" do |f| %>
+        <!-- 名前 -->
+        <div>
+          <%= f.label :name, "名前", class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <%= f.text_field :name,
+                placeholder: "例）あい　るーと",
+                class: "w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm
+                        shadow-inner focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" %>
+        </div>
+
+        <!-- アイコン画像URL -->
+        <div>
+          <%= f.label :avatar_url, "アイコン画像URL（任意）",
+                class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <%= f.url_field :avatar_url,
+                placeholder: "例）https://example.com/my-icon.png",
+                class: "w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm
+                        shadow-inner focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" %>
+
+          <% if @user.avatar_url.present? %>
+            <p class="mt-2 text-xs text-gray-500">
+              現在のアイコンプレビュー
+            </p>
+            <%= image_tag @user.avatar_url,
+                  class: "mt-1 w-16 h-16 rounded-full object-cover border border-slate-200" %>
+          <% end %>
+        </div>
+
+        <!-- ひとこと自己紹介 -->
+        <div>
+          <%= f.label :profile, "ひとこと自己紹介",
+                class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <%= f.text_area :profile,
+                rows: 4,
+                placeholder: "例）サッカーとRailsが好きな日本人です。週末は⚽️試合を肴にビール飲んでます🍺",
+                class: "w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm
+                        shadow-inner focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" %>
+        </div>
+
+        <div class="flex justify-between items-center pt-3 border-t border-slate-100">
+          <%= link_to "キャンセル",
+                      profile_path,
+                      class: "text-xs sm:text-sm text-gray-500 hover:text-gray-700" %>
+
+          <%= f.submit "保存する",
+                class: "px-4 py-2 rounded-lg bg-emerald-500 text-white text-xs sm:text-sm font-medium hover:bg-emerald-600" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,51 @@
+<div class="min-h-[60vh] bg-slate-50">
+  <div class="max-w-md mx-auto px-4 py-8 space-y-6">
+    <div>
+      <p class="text-xs text-gray-500 mb-1">
+        あなたのプロフィール
+      </p>
+      <h1 class="text-xl font-bold text-emerald-600">
+        <%= @user.name.presence || "名前未設定" %>
+      </h1>
+    </div>
+
+    <div class="bg-white rounded-xl shadow-sm border border-slate-200 p-5 space-y-4">
+      <!-- アイコン -->
+      <div class="flex items-center gap-3">
+        <% if @user.avatar_url.present? %>
+          <%= image_tag @user.avatar_url,
+                class: "w-12 h-12 rounded-full object-cover border border-slate-200" %>
+        <% else %>
+          <div class="w-12 h-12 rounded-full bg-emerald-500 text-white flex items-center justify-center text-lg font-semibold">
+            <%= (@user.name.presence || @user.email).first.upcase %>
+          </div>
+        <% end %>
+
+        <div class="text-sm text-gray-700">
+          <p class="font-semibold">
+            <%= @user.name.presence || "名前未設定" %>
+          </p>
+          <p class="text-xs text-gray-500 break-all">
+            <%= @user.email %>
+          </p>
+        </div>
+      </div>
+
+      <!-- ひとこと自己紹介 -->
+      <div>
+        <p class="text-xs font-medium text-gray-500 mb-1">
+          ひとこと自己紹介
+        </p>
+        <p class="text-sm text-gray-700 whitespace-pre-wrap">
+          <%= @user.profile.presence || "まだ自己紹介が登録されていません。" %>
+        </p>
+      </div>
+    </div>
+
+    <div class="flex justify-end">
+      <%= link_to "プロフィールを編集する",
+                  edit_profile_path,
+                  class: "px-4 py-2 rounded-lg bg-emerald-500 text-white text-sm hover:bg-emerald-600" %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -31,20 +31,27 @@
                             border border-emerald-200 rounded
                             hover:bg-emerald-50 font-medium whitespace-nowrap" %>
 
-        <!-- ユーザー情報 -->
-        <div class="flex items-center gap-2 bg-gray-100 px-2 py-1 rounded">
+        <!-- ユーザー情報（全体をプロフィールへのリンクに） -->
+        <%= link_to profile_path, class: "flex items-center gap-2 bg-gray-100 px-2 py-1 rounded no-underline" do %>
 
           <!-- アバター（SP/PC 両方に表示） -->
-          <div class="w-6 h-6 bg-gray-300 rounded-full flex items-center justify-center text-xs text-white">
-            <%= current_user.email.first.upcase %>
-          </div>
+          <% if current_user.avatar_url.present? %>
+          <!-- 画像アイコン（avatar_url がある場合） -->
+            <img src="<%= current_user.avatar_url %>"
+                 alt="avatar"
+                 class="w-6 h-6 rounded-full object-cover border border-slate-300" />
+          <% else %>
+            <!-- 初期アイコン（頭文字） -->
+            <div class="w-6 h-6 bg-gray-300 rounded-full flex items-center justify-center text-xs text-white">
+              <%= current_user.email.first.upcase %>
+            </div>
+          <% end %>
 
           <!-- メールアドレス（PCのみ表示） -->
-          <span class="hidden sm:inline text-gray-600 text-xs sm:text-sm max-w-[140px] truncate">
+          <span class="hidden sm:inline text-gray-600 text-xs sm:text-sm max-w-[140px] truncate hover:text-emerald-600">
             <%= current_user.email %>
           </span>
-
-        </div>
+        <% end %>
 
         <!-- ログアウトボタン -->
         <%= button_to t("header.nav.logout"),

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -37,7 +37,7 @@
       <% if @spot.description.present? %>
         <div>
           <p class="text-xs font-medium text-gray-500 mb-1">メモ（引用や気になるポイント）</p>
-          <p class="text-sm text-gray-700 whitespace-pre-wrap">
+          <p class="text-sm text-gray-700">
             <%= @spot.description %>
           </p>
         </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,6 +5,7 @@ ja:
     nav:
       lists: "行きたいリスト"
       spots: "スポット一覧"
+      profile: "プロフィール"
       login: "ログイン"
       signup: "新規登録"
       logout: "ログアウト"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get "profiles/show"
+  get "profiles/edit"
   root 'lists#index'
 
   devise_for :users
@@ -6,6 +8,7 @@ Rails.application.routes.draw do
   authenticate :user do
     resources :lists
     resources :spots
+    resource :profile, only: %i[show edit update]
   end
 
   # Render スリープ対策用のヘルスチェック

--- a/db/migrate/20251130070928_add_profile_fields_to_users.rb
+++ b/db/migrate/20251130070928_add_profile_fields_to_users.rb
@@ -1,0 +1,7 @@
+class AddProfileFieldsToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :name, :string
+    add_column :users, :avatar_url, :string
+    add_column :users, :profile, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_11_28_192547) do
+ActiveRecord::Schema[7.2].define(version: 2025_11_30_070928) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,6 +42,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_11_28_192547) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name"
+    t.string "avatar_url"
+    t.text "profile"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ProfilesControllerTest < ActionDispatch::IntegrationTest
+  test 'profile controller will be tested later' do
+    skip 'Profile のテストは後続Issueで実装予定'
+  end
+end


### PR DESCRIPTION
## 概要
- ユーザーが自分のプロフィール（名前・ひとこと・アイコンURL）を確認・編集できるようにするための画面と機能を追加

## 変更内容
- User モデルにプロフィール用のカラムを追加（name / avatar_url / profile）
- プロフィールの表示・編集専用の ProfilesController を追加
  - `/profile` でプロフィール詳細
  - `/profile/edit` で編集フォーム
- ヘッダーのユーザー情報エリアをプロフィールページへのリンクに変更
  - avatar_url がある場合は画像アイコンを表示
  - ない場合はメールアドレスの頭文字アイコンを表示
- プロフィール編集フォームで以下を編集可能に
  - 名前（name）
  - ひとこと（profile）
  - アイコン画像URL（avatar_url）

## 変更ファイル
- `db/migrate/20251130070928_add_profile_fields_to_users.rb`
- `db/schema.rb`
- `config/routes.rb`
- `app/controllers/profiles_controller.rb`
- `app/views/profiles/show.html.erb`
- `app/views/profiles/edit.html.erb`
- `app/views/shared/_header.html.erb`

## 動作確認
- [x] ログイン後、ヘッダーのユーザーアイコンから `/profile` に遷移できること
- [x] プロフィール画面で登録メールアドレス・名前・プロフィール文が表示されること
- [x] プロフィール編集画面から name / profile / avatar_url を更新できること
- [x] avatar_url を保存すると、ヘッダーとプロフィール画面のアイコンに画像が表示されること
- [x] avatar_url を空にすると、頭文字アイコンに戻ること
- [x] 未ログイン時には `/profile` にアクセスできないこと（ログイン画面にリダイレクト）

## 関連Issue
- close #59 