### PR TITLE
feat: add list-spot relation via list_items and update UI for lists &…

### DIFF
--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class ListItemsController < ApplicationController
+  before_action :set_list
+
+  def create
+    @list_item = @list.list_items.build(spot_id: params[:spot_id])
+
+    if @list_item.save
+      redirect_back fallback_location: list_path(@list),
+                    notice: 'スポットをリストに追加しました。'
+    else
+      redirect_back fallback_location: list_path(@list),
+                    alert: 'スポットをリストに追加できませんでした。'
+    end
+  end
+
+  def destroy
+    @list_item = @list.list_items.find(params[:id])
+    @list_item.destroy
+
+    redirect_back fallback_location: list_path(@list),
+                  notice: 'リストからスポットを外しました。'
+  end
+
+  private
+
+  def set_list
+    # 自分のリストだけ操作できるよう制限する設定
+    @list = current_user.lists.find(params[:list_id])
+  end
+end

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -2,10 +2,14 @@
 
 class ListsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_list, only: %i[edit update destroy]
+  before_action :set_list, only: %i[show edit update destroy]
 
   def index
     @lists = current_user.lists.order(created_at: :desc)
+  end
+
+  def show
+    @spots = @list.spots.includes(:tags)
   end
 
   def new

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -3,5 +3,8 @@
 class List < ApplicationRecord
   belongs_to :user
 
+  has_many :list_items, dependent: :destroy
+  has_many :spots, through: :list_items
+
   validates :name, presence: true
 end

--- a/app/models/list_item.rb
+++ b/app/models/list_item.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ListItem < ApplicationRecord
+  belongs_to :list
+  belongs_to :spot
+
+  validates :spot_id, uniqueness: { scope: :list_id }
+end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -3,8 +3,9 @@
 class Spot < ApplicationRecord
   belongs_to :user
 
+  has_many :list_items, dependent: :destroy
+  has_many :lists, through: :list_items
+
   validates :title, presence: true
   validates :url, presence: true
-  # has_many :list_items, dependent: :destroy
-  # has_many :lists, through: :list_items
 end

--- a/app/views/lists/index.html.erb
+++ b/app/views/lists/index.html.erb
@@ -11,30 +11,49 @@
 
   <% if @lists.any? %>
     <div class="space-y-3">
-      <% @lists.each do |list| %>
-        <div class="p-3 rounded-lg border bg-white shadow-sm">
-          <div class="flex justify-between items-center gap-3">
+<% @lists.each do |list| %>
+  <div class="p-3 rounded-lg border bg-white shadow-sm">
+          <!-- スマホでは縦並び / sm以上で横並び -->
+          <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3">
             <!-- 左側：リスト情報 -->
             <div>
               <div class="text-xs text-gray-500">
                 作成日: <%= l list.created_at.to_date %>
               </div>
               <div class="font-semibold text-gray-800">
-                <%= list.name %>
+                <span class="block max-w-[180px] truncate sm:max-w-none sm:whitespace-normal">
+                  <%= list.name %>
+                </span>
               </div>
             </div>
 
-            <!-- 右側：編集＆削除ボタン -->
-            <div class="flex gap-2 text-xs">
-              <%= link_to "編集",
-                          edit_list_path(list),
-                          class: "text-gray-500 hover:text-gray-700" %>
+            <!-- 右側：中身を見る / 編集＆削除ボタン -->
+            <div class="flex gap-2 text-xs sm:text-sm sm:justify-end">
+              <!-- 📝 このリストの中身を見る -->
+              <%= link_to list_path(list),
+                          class: "inline-flex items-center gap-1 px-3 py-1 rounded-lg
+                                  border border-slate-300 bg-white text-slate-700
+                                  hover:bg-slate-100 hover:text-slate-900 transition" do %>
+                <span>開く</span>
+              <% end %>
 
-              <%= button_to "削除",
-                            list_path(list),
+              <!-- ✏️ 編集 -->
+              <%= link_to edit_list_path(list),
+                          class: "inline-flex items-center gap-1 px-3 py-1 rounded-lg
+                                  border border-emerald-200 bg-emerald-50 text-emerald-700
+                                  hover:bg-emerald-100 transition" do %>
+                <span>編集</span>
+              <% end %>
+
+              <!-- ❌ 削除 -->
+              <%= button_to list_path(list),
                             method: :delete,
                             data: { turbo_confirm: "このリストを削除しますか？" },
-                            class: "text-red-500 hover:text-red-600" %>
+                            class: "inline-flex items-center gap-1 px-3 py-1 rounded-lg
+                                    border border-red-200 bg-red-50 text-red-700
+                                    hover:bg-red-100 transition" do %>
+                <span>削除</span>
+              <% end %>
             </div>
           </div>
         </div>

--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -1,0 +1,93 @@
+<div class="min-h-[60vh] bg-slate-50">
+  <div class="max-w-3xl mx-auto px-4 py-8 space-y-4">
+
+    <!-- タイトル行：スマホでは縦 / PCでは横 -->
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+      <div>
+        <p class="text-xs text-gray-500 mb-1">行き先リスト</p>
+        <h1 class="text-xl font-bold text-emerald-600 break-words">
+          <span class="block max-w-[220px] truncate sm:max-w-none sm:whitespace-normal">
+            <%= @list.name %>
+          </span>
+        </h1>
+      </div>
+
+      <%= link_to "編集",
+                  edit_list_path(@list),
+                  class: "px-3 py-1 rounded-lg bg-emerald-50 text-emerald-600 border border-emerald-200 hover:bg-emerald-100 text-xs sm:text-sm" %>
+    </div>
+
+    <% if @list.spots.any? %>
+      <div class="space-y-3">
+        <% @list.spots.each do |spot| %>
+          <% list_item = @list.list_items.find { |li| li.spot_id == spot.id } %>
+
+          <div class="bg-white rounded-xl shadow-sm border border-slate-200 p-4">
+            <!-- スポット行：スマホで縦 / PCで横 -->
+            <div class="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-3">
+              <!-- 左：スポット情報 -->
+              <div>
+                <h2 class="font-semibold text-gray-800 text-sm sm:text-base">
+                  <span class="block max-w-[220px] truncate sm:max-w-none sm:whitespace-normal">
+                    <%= spot.title.presence || "（タイトル未入力）" %>
+                  </span>
+                </h2>
+
+                <% if spot.url.present? %>
+                  <a href="<%= spot.url %>"
+                     target="_blank" rel="noopener"
+                     class="inline-flex items-center text-xs text-emerald-600 hover:text-emerald-700 break-all mt-1">
+                    <%= spot.url %>
+                  </a>
+                <% end %>
+              </div>
+
+              <!-- 右：ボタン -->
+              <div class="flex flex-col sm:flex-row items-end sm:items-center gap-2 text-[11px] sm:text-xs">
+                <!-- スポット詳細ボタン -->
+                <%= link_to spot_path(spot),
+                            class: "inline-flex items-center gap-1 px-3 py-1 rounded-lg
+                                    border border-slate-200 bg-white text-gray-700
+                                    hover:bg-slate-50 hover:border-emerald-200 hover:text-emerald-700
+                                    transition" do %>
+                  <span>詳細</span>
+                <% end %>
+
+                <!-- リストから外すボタン -->
+                <% if list_item %>
+                  <%= button_to list_list_item_path(@list, list_item),
+                                method: :delete,
+                                data: { turbo_confirm: "このリストから外しますか？" },
+                                class: "inline-flex items-center gap-1 px-3 py-1 rounded-lg
+                                        border border-red-200 bg-red-50 text-red-700
+                                        hover:bg-red-100 transition" do %>
+                    <span>外す</span>
+                  <% end %>
+                <% end %>
+              </div>
+            </div>
+          </div>
+
+        <% end %>
+      </div>
+    <% else %>
+      <div class="mt-6 rounded-xl border border-dashed border-slate-300 bg-white p-5 text-center">
+        <p class="text-sm text-gray-600">
+          まだこのリストには<br>
+          スポットが追加されていません。
+        </p>
+        <p class="mt-1 text-xs text-gray-500">
+          「📍スポット」一覧から、<br>
+          このリストに追加していきましょう。
+        </p>
+      </div>
+    <% end %>
+
+    <div class="mt-4">
+    <%= link_to "一覧に戻る",
+                lists_path,
+                class: "text-xs sm:text-sm text-gray-500 hover:text-gray-700" %>
+    </div>
+
+  </div>
+</div>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -78,5 +78,34 @@
                       class: "px-3 py-1 rounded-lg bg-red-50 text-red-600 border border-red-200 hover:bg-red-100" %>
       </div>
     </div>
+    <!-- 🔽 リストに追加するUI -->
+    <div class="mt-6 rounded-xl border border-slate-200 bg-white p-4 space-y-3">
+      <p class="text-xs font-medium text-gray-700">
+        このスポットを「行き先リスト」に追加
+      </p>
+
+      <% if current_user.lists.any? %>
+        <div class="flex flex-wrap gap-2">
+          <% current_user.lists.each do |list| %>
+            <%= button_to list_list_items_path(list),
+                          params: { spot_id: @spot.id },
+                          method: :post,
+                          class: "inline-flex items-center gap-1 px-3 py-1.5 rounded-full
+                                  border border-emerald-200 bg-emerald-50 text-emerald-700 text-xs
+                                  hover:bg-emerald-100" do %>
+              <span>📝</span>
+              <span class="truncate max-w-[140px]"><%= list.name %></span>
+            <% end %>
+          <% end %>
+        </div>
+      <% else %>
+        <p class="text-xs text-gray-500">
+          まだ行き先リストがありません。
+          <%= link_to "リストを作成する",
+                      new_list_path,
+                      class: "text-emerald-600 underline decoration-emerald-300" %>
+        </p>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,13 @@
 Rails.application.routes.draw do
-  get "profiles/show"
-  get "profiles/edit"
   root 'lists#index'
 
   devise_for :users
 
   authenticate :user do
-    resources :lists
+    resources :lists do
+      resources :list_items, only: %i[create destroy]
+    end
+
     resources :spots
     resource :profile, only: %i[show edit update]
   end

--- a/db/migrate/20251130095214_create_list_items.rb
+++ b/db/migrate/20251130095214_create_list_items.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateListItems < ActiveRecord::Migration[7.2]
+  def change
+    create_table :list_items do |t|
+      t.references :list, null: false, foreign_key: true
+      t.references :spot, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    # 同じスポットを同じリストに重複登録しないための設定
+    add_index :list_items, %i[list_id spot_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_11_30_070928) do
+ActiveRecord::Schema[7.2].define(version: 2025_11_30_095214) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "list_items", force: :cascade do |t|
+    t.bigint "list_id", null: false
+    t.bigint "spot_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["list_id"], name: "index_list_items_on_list_id"
+    t.index ["spot_id"], name: "index_list_items_on_spot_id"
+  end
 
   create_table "lists", force: :cascade do |t|
     t.string "name", null: false
@@ -49,6 +58,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_11_30_070928) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "list_items", "lists"
+  add_foreign_key "list_items", "spots"
   add_foreign_key "lists", "users"
   add_foreign_key "spots", "users"
 end

--- a/test/fixtures/list_items.yml
+++ b/test/fixtures/list_items.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  list: one
+  spot: one
+
+two:
+  list: two
+  spot: two

--- a/test/models/list_item_test.rb
+++ b/test/models/list_item_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ListItemTest < ActiveSupport::TestCase
+  # test 'the truth' do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要

- 「行きたいスポット」を「行き先リスト」に紐付けるための中間テーブル機能を実装しました。
- スポット詳細画面から、任意のリストにスポットを追加できるようにしました。
- リスト詳細画面で、紐付いているスポット一覧の表示＆「リストから外す」操作ができるようにしました。
- リスト・スポット周りのUIを調整し、スマホ表示でもレイアウトが崩れにくいようにしています。

## 変更内容

### モデル・関連付け

- `List` / `Spot` / `ListItem` の関連付けを定義
  - `List has_many :list_items, dependent: :destroy`
  - `List has_many :spots, through: :list_items`
  - `Spot has_many :list_items, dependent: :destroy`
  - `Spot has_many :lists, through: :list_items`

### コントローラ

- `ListItemsController`
  - `create`：指定したリストに、指定したスポットを追加
  - `destroy`：リストとスポットの紐付けのみ削除（スポット自体は消さない）
- `ListsController`
  - `show`：`@list` の取得処理を追加し、紐付いているスポット一覧を表示

### ルーティング

- `resources :lists do`
  - `resources :list_items, only: %i[create destroy]`
  - `end`
- これにより、以下のようなパスを利用
  - `list_list_items_path(list)` … 追加
  - `list_list_item_path(list, list_item)` … 削除

### 画面（View）

- `app/views/spots/show.html.erb`
  - スポット詳細画面に「このスポットを行き先リストに追加」エリアを追加
  - ログイン中ユーザーのリストをボタンとして表示し、クリックで追加できるように

- `app/views/lists/index.html.erb`
  - 各リストカードに
    - `開く`（リスト詳細へ）
    - `編集`
    - `削除`
    のボタンを配置し、見た目をボタン風に統一

- `app/views/lists/show.html.erb`
  - リスト名＋編集ボタン
  - 紐付いているスポット一覧をカード表示
  - 各スポットに対して
    - `詳細`（スポット詳細へ）
    - `外す`（そのリストからのみ外す）
  - スマホ時にタイトルやスポット名が長くてもレイアウトが崩れないように `truncate` / 幅制限を調整
  - 下部に「一覧に戻る」リンクを追加

## 変更ファイル（一部）

- `app/models/list.rb`
- `app/models/spot.rb`
- `app/models/list_item.rb`
- `app/controllers/list_items_controller.rb`
- `app/controllers/lists_controller.rb`
- `app/views/spots/show.html.erb`
- `app/views/lists/index.html.erb`
- `app/views/lists/show.html.erb`
- `config/routes.rb`

## 動作確認

- [x] ログインユーザーで、スポット詳細から任意のリストに追加できる
- [x] リスト詳細画面で、追加したスポットが一覧表示される
- [x] 「リストから外す」ボタンで、そのリストからだけスポットを外せる（スポット自体は残る）
- [x] リスト削除時に紐付いた `list_items` も同時に削除され、エラーにならない
- [x] スマホ表示でリスト名・スポットタイトルが長くてもレイアウト崩れがない

## 関連Issue

- close #21