### PR TITLE
feature: formの入力削除ボタン実装 + fix: リスト名変更画面からキャンセル時の画面遷移を修正

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,6 +1,6 @@
 @import "tailwindcss";
 
-@source "../../../app/views/**/*";
-@source "../../../app/helpers/**/*.rb";
-@source "../../../app/javascript/**/*.js";
-@source "../../../app/assets/stylesheets/**/*.css";
+@source "../../views/**/*.erb";
+@source "../../helpers/**/*.rb";
+@source "../../javascript/**/*.js";
+@source "../stylesheets/**/*.css";

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -12,3 +12,6 @@ application.register("spot-metadata", SpotMetadataController)
 
 import TagInputController from "./tag_input_controller"
 application.register("tag-input", TagInputController)
+
+import InputClearController from "./input_clear_controller"
+application.register("input-clear", InputClearController)

--- a/app/javascript/controllers/input_clear_controller.js
+++ b/app/javascript/controllers/input_clear_controller.js
@@ -1,0 +1,48 @@
+import { Controller } from "@hotwired/stimulus"
+
+// data-controller="input-clear" 用
+export default class extends Controller {
+  static targets = ["input", "clear"]
+
+  connect() {
+    // デバッグ用↓↓↓
+    console.log(" @@@ input-clear connected", this.element)
+
+    this.refresh()
+  }
+    // 初期表示時にボタン表示/非表示を決める
+    // this.toggle("input-clear connected", this.element)
+
+
+  // 入力値に応じて X ボタンの表示を切り替え
+  refresh() {
+    if (!this.hasInputTarget || !this.hasClearTarget) {
+
+      return
+    }
+
+    const empty = this.inputTarget.value.trim() === ""
+    this.clearTarget.classList.toggle("hidden", empty)
+  }
+
+  // 入力中に呼ばれる（data-action="input->input-clear#refresh" にする）
+  toggle() {
+    this.refresh()
+  }
+
+  // クリア処理
+  clear(event) {
+    event.preventDefault()
+
+    if (!this.hasInputTarget || !this.hasClearTarget) return
+
+    console.log("@@@ clear clicked", this.inputTarget)
+
+    this.inputTarget.value = ""
+    this.refresh()
+    this.inputTarget.focus()
+
+    // 他の controller（spot-metadata など）が input を監視してる場合があるので、 input イベントを発火させる
+    this.inputTarget.dispatchEvent(new Event("input", { bubbles: true }))
+  }
+}

--- a/app/javascript/controllers/spot_metadata_controller.js
+++ b/app/javascript/controllers/spot_metadata_controller.js
@@ -5,17 +5,18 @@ export default class extends Controller {
     "url",
     "title",
     "description",
+    "memo",
     "imageUrl",
     "imagePreviewWrapper",
     "imagePreview"
   ]
+
   //コピペ投下でnokogiri自動でかかる設定
   handlePaste(event) {
     // paste イベントのタイミングだと、まだ value が更新されていないことがあるので
     // 少しだけ遅らせてから fetchMetadata を呼ぶ　というロジック。
     setTimeout(() => this.fetchMetadata(), 0)
   }
-
 
   // URL入力後にnokogiri呼び出す設定
   async fetchMetadata(event) {
@@ -55,7 +56,7 @@ export default class extends Controller {
         this.imageUrlTarget.value = data.image_url
       }
 
-      // 👇 画像プレビューを更新する設定
+      // 画像プレビューを更新する設定
       if (data.image_url && this.hasImagePreviewTarget && this.hasImagePreviewWrapperTarget) {
         this.imagePreviewTarget.src = data.image_url
         this.imagePreviewWrapperTarget.classList.remove("hidden")
@@ -81,5 +82,70 @@ export default class extends Controller {
   // プレビュー表示
     this.imagePreviewTarget.src = url
     this.imagePreviewWrapperTarget.classList.remove("hidden")
+  }
+
+  clearImage() {
+    if (this.hasImageUrlTarget) {
+      this.imageUrlTarget.value = ""
+      this.imageUrlTarget.dispatchEvent(new Event("input", { bubbles: true }))
+    }
+
+    if (this.hasImagePreviewTarget && this.hasImagePreviewWrapperTarget) {
+      this.imagePreviewTarget.src = ""
+      this.imagePreviewWrapperTarget.classList.add("hidden")
+    }
+  }
+
+  // 自動入力された内容（title / description / image_url / preview）をまとめてクリアするボタン
+  clearAutoFilled() {
+    if (this.hasTitleTarget) this.titleTarget.value = ""
+    if (this.hasDescriptionTarget) this.descriptionTarget.value = ""
+    if (this.hasImageUrlTarget) this.imageUrlTarget.value = ""
+
+    if (this.hasImagePreviewTarget && this.hasImagePreviewWrapperTarget) {
+        this.imagePreviewTarget.src = ""
+        this.imagePreviewWrapperTarget.classList.add("hidden")
+    }
+  }
+
+ // ===== 各項目のクリアボタン設定 =====
+  clearUrlField() {
+    if (!this.hasUrlTarget) return
+    this.urlTarget.value = ""
+    this.urlTarget.focus()
+  }
+
+  clearTitleField() {
+    if (!this.hasTitleTarget) return
+    this.titleTarget.value = ""
+    this.titleTarget.focus()
+  }
+
+  clearDescriptionField() {
+    if (!this.hasDescriptionTarget) return
+    this.descriptionTarget.value = ""
+    this.descriptionTarget.focus()
+  }
+
+  clearMemoField() {
+    if (!this.hasMemoTarget) return
+    this.memoTarget.value = ""
+    this.memoTarget.focus()
+  }
+
+  // 画像URL + プレビュー両方クリア
+  clearImageUrlField() {
+    if (this.hasImageUrlTarget) {
+      this.imageUrlTarget.value = ""
+    }
+    this.updateImagePreview()
+  }
+
+  // プレビューだけ消したい時用（image_url は残す）
+  clearImagePreviewOnly() {
+    if (!this.hasImagePreviewTarget || !this.hasImagePreviewWrapperTarget) return
+
+    this.imagePreviewTarget.src = ""
+    this.imagePreviewWrapperTarget.classList.add("hidden")
   }
 }

--- a/app/views/lists/edit.html.erb
+++ b/app/views/lists/edit.html.erb
@@ -46,7 +46,7 @@
 
         <div class="flex items-center justify-between pt-3 border-t border-slate-100">
           <%= link_to "キャンセル",
-                      lists_path,
+                      list_path(@list),
                       class: "text-xs sm:text-sm text-gray-500 hover:text-gray-700" %>
 
           <div class="flex gap-2">

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -12,21 +12,41 @@
     </div>
   <% end %>
 
-  <%= form_with model: spot, local: true, class: "space-y-5", data: { controller: "spot-metadata" } do |f| %>
+  <%= form_with model: spot,
+                local: true,
+                class: "space-y-5",
+                data: { controller: "spot-metadata" } do |f| %>
+
     <!-- URL -->
     <div>
       <div class="flex items-center justify-between mb-1">
         <%= f.label :url, "スポットのURL", class: "block text-sm font-medium text-gray-700" %>
         <span class="text-xs text-emerald-500">必須</span>
       </div>
-      <%= f.url_field :url,
-            placeholder: "例）https://example.com/nice-spot",
-            class: "w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm
-                    shadow-inner focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500",
-            data: {
-              spot_metadata_target: "url",
-              action: "input->spot-metadata#fetchMetadata"
-            } %>
+
+      <div class="relative w-full overflow-hidden">
+        <%= f.url_field :url,
+              placeholder: "例）https://example.com/nice-spot",
+              class: "w-full rounded-lg border border-slate-300 bg-white px-3 py-2 pr-12 text-sm
+                      shadow-inner focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500",
+              data: {
+                spot_metadata_target: "url",
+                action: "paste->spot-metadata#handlePaste blur->spot-metadata#fetchMetadata"
+              } %>
+
+        <!-- URL のクリアボタン -->
+        <button
+          type="button"
+          data-action="click->spot-metadata#clearUrlField"
+          class="absolute inset-y-0 right-0 my-auto
+                 w-6 h-6
+                 rounded-full bg-slate-200/90 backdrop-blur
+                 text-slate-700 hover:bg-slate-400
+                 text-[12px] leading-none font-bold transition"
+        >
+          ×
+        </button>
+      </div>
     </div>
 
     <!-- タイトル -->
@@ -35,19 +55,37 @@
         <%= f.label :title, "タイトル", class: "block text-sm font-medium text-gray-700" %>
         <span class="text-xs text-emerald-500">必須</span>
       </div>
-      <%= f.text_field :title,
-            placeholder: "例）雰囲気最高の夜景バー",
-            class: "w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm
-                    shadow-inner focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500",
-            data: { spot_metadata_target: "title" } %>
+
+      <div class="relative w-full overflow-hidden">
+        <%= f.text_field :title,
+              placeholder: "例）雰囲気最高の夜景バー",
+              class: "w-full rounded-lg border border-slate-300 bg-white px-3 py-2 pr-12 text-sm
+                      shadow-inner focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500",
+              data: {
+                spot_metadata_target: "title"
+              } %>
+        <!-- タイトル のクリアボタン -->
+        <button
+          type="button"
+          data-action="click->spot-metadata#clearTitleField"
+          class="absolute right-0 top-1/2 -translate-y-1/2
+                 w-6 h-6
+                 rounded-full bg-slate-200/90 backdrop-blur
+                 text-slate-700 hover:bg-slate-400
+                 text-[12px] leading-none font-bold transition"
+        >
+          ×
+        </button>
+      </div>
     </div>
 
-      <!-- メモ（description） -->
-      <div>
-        <%= f.label :description,
-              "メモ（引用や気になるポイントなど）",
-              class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <!-- メモ（description） -->
+    <div>
+      <%= f.label :description,
+            "メモ（引用や気になるポイントなど）",
+            class: "block text-sm font-medium text-gray-700 mb-1" %>
 
+      <div class="relative w-full overflow-hidden">
         <!-- 外枠（白） -->
         <div class="rounded-lg border border-slate-300 bg-white">
           <!-- スクロール可能エリア（グレー） -->
@@ -56,40 +94,87 @@
                   rows: 3,
                   placeholder: "気になった理由や、サイトからの引用メモなどを書いておきましょう。",
                   class: "w-full bg-transparent border-none focus:outline-none text-sm resize-none",
-                  data: { spot_metadata_target: "description" } %>
+                  data: {
+                    spot_metadata_target: "description"
+                  } %>
+
+            <!-- メモ のクリアボタン -->
+            <button
+              type="button"
+              class="mt-2 inline-flex items-center px-3 py-1 rounded-md text-[11px]
+                     border border-slate-300 bg-white text-slate-600 hover:bg-slate-100"
+              data-action="click->spot-metadata#clearDescriptionField"
+            >
+              メモをクリア
+            </button>
           </div>
         </div>
       </div>
+    </div>
 
     <!-- ひとことメモ -->
     <div>
       <%= f.label :memo, "ひとことメモ（相手に伝えたいこと）",
             class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.text_field :memo,
-            placeholder: "例）記念日に使いたい / 個室あり / 雨の日でもOK など",
-            class: "w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm
-                    shadow-inner focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500" %>
+
+      <div class="relative w-full overflow-hidden">
+        <%= f.text_field :memo,
+              placeholder: "例）記念日に使いたい / 個室あり / 雨の日でもOK など",
+              class: "w-full rounded-lg border border-slate-300 bg-white px-3 py-2 pr-12 text-sm
+                      shadow-inner focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500",
+              data: {
+                spot_metadata_target: "memo"
+              } %>
+        <!-- ひとことメモ のクリアボタン -->
+        <button
+          type="button"
+          data-action="click->spot-metadata#clearMemoField"
+          class="absolute right-0 top-1/2 -translate-y-1/2
+                 w-6 h-6
+                 rounded-full bg-slate-200/90 backdrop-blur
+                 text-slate-700 hover:bg-slate-400
+                 text-[12px] leading-none font-bold transition"
+        >
+          ×
+        </button>
+      </div>
     </div>
 
     <!-- 画像URL（任意） -->
     <div>
       <%= f.label :image_url, "画像URL（任意）",
             class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.url_field :image_url,
-            placeholder: "サムネイル用の画像URLがあれば入力",
-            class: "w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm
-                    shadow-inner focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500",
-            data: {
-              spot_metadata_target: "imageUrl",
-              action: "input->spot-metadata#updateImagePreview"
-            } %>
 
+      <div class="relative w-full">
+        <%= f.url_field :image_url,
+              placeholder: "サムネイル用の画像URLがあれば入力",
+              class: "w-full rounded-lg border border-slate-300 bg-white px-3 py-2 pr-10 text-sm
+                      shadow-inner focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500",
+              data: {
+                spot_metadata_target: "imageUrl",
+                action: "input->spot-metadata#updateImagePreview"
+              } %>
+
+      <!-- 画像プレビュー -->
       <div
         data-spot-metadata-target="imagePreviewWrapper"
         class="mt-3 <%= 'hidden' if spot.image_url.blank? %>">
-        <%= image_tag(spot.image_url.presence || "",
+        <%= image_tag(
+              spot.image_url.presence || "",
               class: "w-full max-h-48 object-cover rounded-lg border border-slate-200",
-              data: { spot_metadata_target: "imagePreview" }) %>
+              data: { spot_metadata_target: "imagePreview" }
+            ) %>
+
+      <!-- プレビューのクリアボタン -->
+        <button
+          type="button"
+          class="mt-2 inline-flex items-center px-3 py-1 rounded-md text-[11px]
+                 border border-slate-300 bg-white text-slate-600
+                 hover:bg-slate-100"
+          data-action="click->spot-metadata#clearImage"
+        >
+          画像プレビューをクリア
+        </button>
       </div>
     </div>
 
@@ -123,9 +208,10 @@
       <% end %>
     </div>
 
-    <!-- タグ入力(tagging) タグチップにして(x)削除可能に-->
+    <!-- タグ入力(tagging) -->
     <div
-      data-controller="tag-input" data-tag-input-initial-tags-value="<%= spot.tag_names %>"
+      data-controller="tag-input"
+      data-tag-input-initial-tags-value="<%= spot.tag_names %>"
     >
       <p class="text-xs font-medium text-gray-700 mb-1">
         タグをつけておくと、あとで見返しやすくなります。<br>
@@ -135,9 +221,8 @@
         </span>
       </p>
 
-      <!-- チップを並べるエリア => (× デート) みたいなタグがここに生える-->
-      <div class="flex flex-wrap gap-2 mb-2" data-tag-input-target="chips">
-      </div>
+      <!-- チップを並べるエリア -->
+      <div class="flex flex-wrap gap-2 mb-2" data-tag-input-target="chips"></div>
 
       <!-- 追加用インプット -->
       <input
@@ -159,9 +244,8 @@
     <div class="flex items-center justify-between pt-3 border-t border-slate-100">
       <% cancel_path =
             if request.referer.present?
-               request.referer
+              request.referer
             else
-              # 直前URLが取れないレアケース用の保険
               spot.persisted? ? spot_path(spot) : spots_path
             end %>
 
@@ -169,7 +253,18 @@
                   cancel_path,
                   class: "text-xs sm:text-sm text-gray-500 hover:text-gray-700" %>
 
-      <div class="flex gap-2">
+      <div class="flex gap-2 items-center">
+        <!-- 自動入力リセットボタン -->
+        <button
+          type="button"
+          class="inline-flex items-center px-4 py-2 rounded-lg text-[11px] sm:text-xs
+                 border border-slate-300 bg-white text-slate-600
+                 hover:bg-slate-100"
+          data-action="click->spot-metadata#clearAutoFilled"
+        >
+          自動入力をリセット
+        </button>
+
         <%= f.submit "保存する",
               class: "inline-flex items-center px-4 py-2 rounded-lg text-xs sm:text-sm
                       bg-emerald-500 text-white font-medium hover:bg-emerald-600

--- a/docker
+++ b/docker
@@ -1,0 +1,27 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:15
+    container_name: ai_route_db
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  web:
+    build: .
+    container_name: ai_route_web
+    command: bash -c "rm -f tmp/pids/server.pid && bin/rails server -b 0.0.0.0"
+    volumes:
+      - .:/app
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+
+volumes:
+  db-data:


### PR DESCRIPTION
## 概要
フォーム入力画面で各項目を入力中に削除できるよう削除ボタンを実装しました。
また、リスト名編集画面で「キャンセル」を押した際、  
一覧（index）ではなく対象リストの詳細（show）画面に戻るように修正しました。

---

##  変更内容
- フォームの削除ボタン実装
- リスト名編集画面（list edit）からのキャンセル遷移先を修正
- 編集元のリスト詳細画面（list show）に戻るよう挙動を改善

---

## 変更ファイル
- `app/views/lists/edit.html.erb`  
- `app/views/lists/_form.html.erb`
- `app/javascript/controllers/spot_metadata_controller.js`

---

## 動作確認
- formの削除が各項目できている
- list index → list show → list edit → キャンセル  
  → **list show に戻ることを確認**

---

## 関連Issue
- #32 