### PR TITLE
ページフッターの実装と各画面遷移の調整

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -4,4 +4,6 @@ class StaticPagesController < ApplicationController
   skip_before_action :authenticate_user!, only: :landing
 
   def landing; end
+  def terms; end
+  def privacy; end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,5 +47,6 @@
 
       <%= yield %>
     </main>
+    <%= render "shared/footer" %>
   </body>
 </html>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,0 +1,29 @@
+<footer class="mt-16 bg-emerald-400 text-gray-800">
+  <div class="max-w-4xl mx-auto px-4 py-6 text-center">
+    <!-- リンク群 -->
+    <nav class="mb-3 flex justify-center gap-4 text-sm">
+      <%= link_to "利用規約",
+            terms_path,
+            class: "hover:underline hover:text-emerald-900" %>
+
+      <span>|</span>
+
+      <%= link_to "プライバシーポリシー",
+            privacy_path,
+            class: "hover:underline hover:text-emerald-900" %>
+
+      <span>|</span>
+
+      <% if user_signed_in? %>
+        <%= link_to "お問い合わせ",
+              new_contact_messages_path,
+              class: "hover:underline hover:text-emerald-900" %>
+      <% end %>
+    </nav>
+
+    <!-- コピーライト -->
+    <p class="text-xs text-gray-700">
+      © 2025 AiRoute
+    </p>
+  </div>
+</footer>

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,0 +1,77 @@
+<div class="bg-white rounded-xl shadow-sm border border-slate-200 p-6 sm:p-8">
+  <h1 class="text-xl sm:text-2xl font-bold text-gray-900 mb-2">プライバシーポリシー</h1>
+  <p class="text-xs text-gray-500 mb-6">最終更新日：2025年12月14日</p>
+
+  <div class="space-y-6 text-sm text-gray-700 leading-relaxed">
+    <section>
+      <h2 class="font-semibold text-gray-900 mb-2">1. 取得する情報</h2>
+      <ul class="list-disc list-inside space-y-1">
+        <li>アカウント登録情報（例：メールアドレス等）</li>
+        <li>ユーザーが入力する情報（スポットURL、メモ、タグ等）</li>
+        <li>お問い合わせ内容（氏名、メールアドレス、件名、本文等）</li>
+        <li>アクセス情報（ログ、IPアドレス、ブラウザ情報等）※サーバ運用上必要な範囲</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2 class="font-semibold text-gray-900 mb-2">2. 利用目的</h2>
+      <ul class="list-disc list-inside space-y-1">
+        <li>本サービスの提供・運営のため</li>
+        <li>不正利用防止・セキュリティ確保のため</li>
+        <li>お問い合わせ対応のため</li>
+        <li>改善・品質向上のための分析（個人を特定しない形）</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2 class="font-semibold text-gray-900 mb-2">3. 第三者提供</h2>
+      <p>
+        取得した個人情報は、法令に基づく場合を除き、本人の同意なく第三者に提供しません。
+      </p>
+    </section>
+
+    <section>
+      <h2 class="font-semibold text-gray-900 mb-2">4. 外部サービス・リンク</h2>
+      <p>
+        本サービスでは、ユーザーが入力したURLのメタ情報を取得するため外部サイトへアクセスする場合があります。
+        外部サイトにおける情報の取扱いについては、各サイトの方針をご確認ください。
+      </p>
+    </section>
+
+    <section>
+      <h2 class="font-semibold text-gray-900 mb-2">5. 保管期間</h2>
+      <p>
+        個人情報は、利用目的達成に必要な期間保持し、不要となった場合は適切に削除します。
+      </p>
+    </section>
+
+    <section>
+      <h2 class="font-semibold text-gray-900 mb-2">6. 安全管理</h2>
+      <p>
+        個人情報の漏えい、滅失、毀損等を防止するため、合理的な安全対策を講じます。
+      </p>
+    </section>
+
+    <section>
+      <h2 class="font-semibold text-gray-900 mb-2">7. 開示・訂正・削除</h2>
+      <p>
+        ユーザーは、自己の個人情報について開示・訂正・削除を求めることができます。
+        ご希望の場合は、お問い合わせフォームよりご連絡ください。
+      </p>
+    </section>
+
+    <section>
+      <h2 class="font-semibold text-gray-900 mb-2">8. 本ポリシーの変更</h2>
+      <p>
+        必要に応じて本ポリシーを変更します。変更後の内容は本サービス上に表示した時点で効力を生じます。
+      </p>
+    </section>
+
+    <section>
+      <h2 class="font-semibold text-gray-900 mb-2">9. お問い合わせ</h2>
+      <p>
+        個人情報の取扱いに関するお問い合わせは、お問い合わせフォームよりご連絡ください。
+      </p>
+    </section>
+  </div>
+</div>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,0 +1,88 @@
+<div class="bg-white rounded-xl shadow-sm border border-slate-200 p-6 sm:p-8">
+  <h1 class="text-xl sm:text-2xl font-bold text-gray-900 mb-2">利用規約</h1>
+  <p class="text-xs text-gray-500 mb-6">最終更新日：2025年12月14日</p>
+
+  <div class="space-y-6 text-sm text-gray-700 leading-relaxed">
+    <section>
+      <h2 class="font-semibold text-gray-900 mb-2">1. はじめに</h2>
+      <p>
+        本利用規約（以下「本規約」）は、AiRoute（以下「本サービス」）の利用条件を定めるものです。
+        ユーザーは、本規約に同意したうえで本サービスを利用するものとします。
+      </p>
+    </section>
+
+    <section>
+      <h2 class="font-semibold text-gray-900 mb-2">2. 提供内容</h2>
+      <p>
+        本サービスは、ユーザーがスポットURL等の情報を登録し、行き先リストとして整理・閲覧できる機能を提供します。
+        URLから取得されるメタ情報（タイトル・画像等）は、外部サイトの状況により取得できない場合があります。
+      </p>
+    </section>
+
+    <section>
+      <h2 class="font-semibold text-gray-900 mb-2">3. アカウント</h2>
+      <ul class="list-disc list-inside space-y-1">
+        <li>ユーザーは、登録情報を正確かつ最新の状態に保つものとします。</li>
+        <li>アカウントの管理責任はユーザーにあります。</li>
+        <li>第三者による不正利用等について、本サービスは合理的な範囲を除き責任を負いません。</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2 class="font-semibold text-gray-900 mb-2">4. 禁止事項</h2>
+      <ul class="list-disc list-inside space-y-1">
+        <li>法令または公序良俗に反する行為</li>
+        <li>他者の権利（著作権・商標権・プライバシー等）を侵害する行為</li>
+        <li>不正アクセス、スパム、過度な負荷をかける行為</li>
+        <li>本サービスの運営を妨げる行為</li>
+        <li>その他、運営者が不適切と判断する行為</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2 class="font-semibold text-gray-900 mb-2">5. 知的財産権</h2>
+      <p>
+        本サービスに関する表示、デザイン、プログラム等に関する権利は運営者または正当な権利者に帰属します。
+        ユーザーが登録したコンテンツ（URL、メモ等）の権利はユーザーに帰属しますが、
+        運営上必要な範囲で本サービスが表示・保存・処理することを許諾するものとします。
+      </p>
+    </section>
+
+    <section>
+      <h2 class="font-semibold text-gray-900 mb-2">6. 免責事項</h2>
+      <ul class="list-disc list-inside space-y-1">
+        <li>本サービスは、内容の正確性・完全性・有用性を保証しません。</li>
+        <li>外部サイトの情報・リンク先について本サービスは責任を負いません。</li>
+        <li>システム障害・メンテナンス等により利用できない場合があります。</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2 class="font-semibold text-gray-900 mb-2">7. サービスの変更・停止</h2>
+      <p>
+        運営者は、ユーザーへの事前通知なく本サービスの内容変更、提供の中断・停止を行う場合があります。
+      </p>
+    </section>
+
+    <section>
+      <h2 class="font-semibold text-gray-900 mb-2">8. 規約の変更</h2>
+      <p>
+        運営者は、必要に応じて本規約を変更できます。変更後の規約は、本サービス上に表示した時点で効力を生じます。
+      </p>
+    </section>
+
+    <section>
+      <h2 class="font-semibold text-gray-900 mb-2">9. 準拠法・裁判管轄</h2>
+      <p>
+        本規約は日本法に準拠し、本サービスに関して紛争が生じた場合、運営者所在地を管轄する裁判所を専属的合意管轄とします。
+      </p>
+    </section>
+
+    <section>
+      <h2 class="font-semibold text-gray-900 mb-2">10. お問い合わせ</h2>
+      <p>
+        本サービスに関するお問い合わせは、お問い合わせフォームよりご連絡ください。
+      </p>
+    </section>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
   root 'static_pages#landing'
   # ログイン前後どっちでも見られる説明ページ
   get '/about', to: 'static_pages#landing', as: :about
+  get '/terms',   to: 'static_pages#terms',   as: :terms
+  get '/privacy', to: 'static_pages#privacy', as: :privacy
 
   # ログイン後の root
   authenticated :user do


### PR DESCRIPTION
## 概要
footer のレイアウトを追加し利用規約等の画面遷移を調整。
よりアプリとして信頼感を得られるようにプライバシーポリシーや©︎マークも実装しました。

## 変更内容
- footer を画面下部に配置するため、親要素のレイアウト構造を見直し
- 既存のデザインに合わせて統一感を出した

## 変更ファイル
- app/views/layouts/application.html.erb
- app/assets/tailwind/application.css（footer 関連）

## 動作確認
- ローカル環境で以下を確認
  - スクロールが発生するページでは自然に footer が最下部に表示される
  - 既存ページのレイアウト崩れがないこと

## 関連Issue
- #35 