### PR TITLE
Devise / Rails標準の #error_explanation😢

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -23,8 +23,6 @@
       method: :post,
       html: { class: "space-y-6", data: { turbo: false } } do |f| %>
 
-      <%= render "devise/shared/error_messages", resource: resource %>
-
       <div>
         <%= f.label :email, t("devise.registrations.new.email"),
                     class: "block font-medium mb-1" %>


### PR DESCRIPTION
概要：
<%= render "devise/shared/error_messages", resource: resource %>消し忘れててた😢

```
<%#= render "devise/shared/error_messages", resource: resource %>
```
コメントアウトも見づらいんで完全に削除しました。
卒制終盤だからって気を抜いてしまった。反省。