### PR TITLE
fix: pin minitest v5 to stabilize ci-test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,13 +48,16 @@ group :development, :test do
   gem 'brakeman', '~> 8.0', require: false # セキュリティ診断
   gem 'debug', platforms: %i[mri windows], require: 'debug/prelude'
   gem 'rubocop-rails-omakase', require: false
+
+  # Rails 7.2.3 + CI 安定化目的（minitest6対策）
+  gem 'minitest', '~> 5.0'
 end
 
 # ========================================
 # 開発専用
 # ========================================
 group :development do
-  gem 'web-console' # エラー画面の console
+  gem 'web-console'
 end
 
 # ========================================

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
     marcel (1.1.0)
     matrix (0.4.3)
     mini_mime (1.1.5)
-    minitest (5.26.2)
+    minitest (5.27.0)
     msgpack (1.8.0)
     net-imap (0.5.12)
       date
@@ -336,6 +336,7 @@ DEPENDENCIES
   devise-i18n
   importmap-rails
   jbuilder
+  minitest (~> 5.0)
   nokogiri
   pg (~> 1.1)
   puma (>= 5.0)


### PR DESCRIPTION
 - 目的: CIのtest jobがrailties ... line_filtering.rbで、"ArgumentError" を出して落ちるため、テストランナーを安定化。
 - 変更: minitest ~> 5.0 を追加してv6を避ける（Rails 7.2.3 との組み合わせで互換問題が出ていたため）。