### PR TITLE
chore: enable system tests in docker (chromium + driver)

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,6 +9,20 @@ RUN apt-get update -qq && \
       build-essential git curl \
       libpq-dev postgresql-client \
       libvips \
+      chromium \
+      chromium-driver \
+      fonts-liberation \
+      libnss3 \
+      libatk-bridge2.0-0 \
+      libgtk-3-0 \
+      libgbm1 \
+      libasound2 \
+      libx11-xcb1 \
+      libxcomposite1 \
+      libxdamage1 \
+      libxrandr2 \
+      libxshmfence1 \
+      xdg-utils \
     && rm -rf /var/lib/apt/lists/*
 
 ENV RAILS_ENV=development \

--- a/README.md
+++ b/README.md
@@ -175,3 +175,12 @@ https://www.figma.com/design/LEEt7T5T72Ts4IjRKVjc0u/%E5%8D%92%E5%88%B6-AiRoute-?
 
 - MVPでは「いいね整理アプリ」として完結
 - 将来的にはAIによるプラン自動生成・マップ提案へ拡張予定
+
+### System Test (Docker)
+
+```bash
+docker compose build web
+docker compose run --rm web bundle exec rails test test:system
+```
+
+Chromium + chromedriver を Docker 内で実行して system test を動作させます。


### PR DESCRIPTION
 - 概要：Docker環境でsystem testが落ちる問題を解消
 - 変更内容：Dockerfile.devにchromium/chromedriver等を追加、READMEに実行手順追記
 - 動作確認：docker compose run --rm web bundle exec rails test test:system が通る
 - 影響範囲：dev/testのみ（本番Dockerfileに影響なし）