### PR TITLE
fix: brakeman ignoreのお掃除

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,24 +1,4 @@
 {
-  "ignored_warnings": [
-    {
-      "warning_type": "Unmaintained Dependency",
-      "warning_code": 123,
-      "fingerprint": "715ee6d743a8af33c7b930d728708ce19c765fb40e2ad9d2b974db04d92dc7d1",
-      "check_name": "EOLRuby",
-      "message": "Support for Ruby 3.2.2 ends on 2026-03-31",
-      "file": ".ruby-version",
-      "line": 1,
-      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
-      "code": null,
-      "render_path": null,
-      "location": null,
-      "user_input": null,
-      "confidence": "Weak",
-      "cwe_id": [
-        1104
-      ],
-      "note": ""
-    }
-  ],
-  "brakeman_version": "7.1.1"
+  "ignored_warnings": [],
+  "brakeman_version": "8.0.4"
 }


### PR DESCRIPTION
## 概要

Brakeman の警告運用を整理し、CI 上で安定してセキュリティスキャンが通る状態にしました。
不要となっていた ignore 設定を削除し、警告ゼロで実行できる状態を確認しています。


## 変更内容

	•	config/brakeman.ignore の obsolete entry を削除
	•	ignore を空配列へ整理
	•	brakeman_version を現行実行環境（8.0.4）へ更新
	•	ローカルで warning 0 を確認


変更ファイル

	•	config/brakeman.ignore


動作確認
ローカルで以下を実行し、警告ゼロで通ることを確認済みです。

	•	docker compose run --rm web bash -lc "bundle exec brakeman" 

## 関連issue
 close #120 