### PR TITLE
未ログイン時でも利用規約・プライバシーポリシーを閲覧できるよう修正

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class StaticPagesController < ApplicationController
-  skip_before_action :authenticate_user!, only: :landing
+  skip_before_action :authenticate_user!
 
   def landing; end
   def terms; end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,23 +1,14 @@
 <footer class="mt-16 bg-emerald-400 text-gray-800">
   <div class="max-w-4xl mx-auto px-4 py-6 text-center">
     <!-- リンク群 -->
-    <nav class="mb-3 flex justify-center gap-4 text-sm">
-      <%= link_to "利用規約",
-            terms_path,
-            class: "hover:underline hover:text-emerald-900" %>
-
+    <nav class="mb-3 flex justify-center gap-3 text-sm flex-wrap">
+      <%= link_to "利用規約", terms_path, class: "hover:underline hover:text-emerald-900" %>
       <span>|</span>
-
-      <%= link_to "プライバシーポリシー",
-            privacy_path,
-            class: "hover:underline hover:text-emerald-900" %>
-
-      <span>|</span>
+      <%= link_to "プライバシーポリシー", privacy_path, class: "hover:underline hover:text-emerald-900" %>
 
       <% if user_signed_in? %>
-        <%= link_to "お問い合わせ",
-              new_contact_messages_path,
-              class: "hover:underline hover:text-emerald-900" %>
+        <span>|</span>
+        <%= link_to "お問い合わせ", new_contact_messages_path, class: "hover:underline hover:text-emerald-900" %>
       <% end %>
     </nav>
 


### PR DESCRIPTION
# 概要
未ログインユーザーでも  **利用規約・プライバシーポリシーを確認できるように修正**しました。

これにより、アカウント登録前でもサービス利用条件を確認できる状態となり、  
UXおよび一般的なWebサービスの設計に沿った構成になります。

# 変更内容

## 1. StaticPagesControllerの認証スキップ範囲を変更
### 変更前
```ruby
skip_before_action :authenticate_user!, only: :landing
```
### 変更後
```ruby
skip_before_action :authenticate_user! 
```
これにより StaticPagesController の全アクションが公開ページとして扱われます。

## 2.フッターリンクの整理
- flex-wrap を追加（スマホ表示の崩れ防止）
- 区切り線 | をログイン状態に応じて適切に表示するよう修正
- お問い合わせ はログインユーザーのみ表示

## 変更ファイル
`app/controllers/static_pages_controller.rb`
`app/views/shared/_footer.html.erb`